### PR TITLE
Unified properties in response schemas + minor fixes

### DIFF
--- a/prosoprAPhI.yaml
+++ b/prosoprAPhI.yaml
@@ -35,6 +35,7 @@ paths:
         - $ref: "#/components/parameters/from"
         - $ref: "#/components/parameters/to"
         - $ref: "#/components/parameters/place"
+        - $ref: "#/components/parameters/sortBy"
       responses:
         "200":
           description: A list of Factoids with some metadata
@@ -135,10 +136,7 @@ paths:
           content:
             application/json:
               schema:
-                title: Array of Person objects
-                type: array
-                items:
-                  $ref: "#/components/schemas/Person"
+                  $ref: "#/components/schemas/PersonsResponse"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "500":
@@ -238,10 +236,7 @@ paths:
           content:
             application/json:
               schema:
-                title: Array of Source objects
-                type: array
-                items:
-                  $ref: "#/components/schemas/Source"
+                $ref: "#/components/schemas/SourcesResponse"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "500":
@@ -445,6 +440,8 @@ components:
       schema:
         type: string
     sortBy:
+      # TODO: this must be more precise: allowed values per endpoint
+      # TODO: how to address properties not on level 0?
       name: sortBy
       in: query
       description: defines the sort order of the requested resource, can contain all
@@ -789,7 +786,7 @@ components:
         properties:
             protocol: 
               $ref: "#/components/schemas/Protocol"
-            factoids:
+            data:
                 type: array
                 items:
                   $ref: "#/components/schemas/Factoid"
@@ -798,7 +795,7 @@ components:
             - size: 30
             - totalHits: 1234
             - page: 2
-          - factoids: 
+          - data: 
             - "@id": TW_Pez1_809_1
               person: Andreas_Reuter
               statements:
@@ -875,7 +872,7 @@ components:
         properties:
             protocol: 
               $ref: "#/components/schemas/Protocol"
-            persons:
+            data:
                 type: array
                 items:
                   $ref: "#/components/schemas/Person"
@@ -884,7 +881,7 @@ components:
             - size: 30
             - totalHits: 12345
             - page: 2
-          - persons:                   
+          - data:                   
             - "@id": Andreas_Reuter
             - uris:
                 - http://pez-digital.at/persons#Mauro_Aspini
@@ -1024,7 +1021,7 @@ components:
         properties:
             protocol: 
               $ref: "#/components/schemas/Protocol"
-            persons:
+            data:
                 type: array
                 items:
                   $ref: "#/components/schemas/Statement"
@@ -1033,7 +1030,7 @@ components:
             - size: 30
             - totalHits: 1234
             - page: 2
-          - statements: 
+          - data: 
             - "@id": st1
             - ...
             - "@id": st2
@@ -1088,7 +1085,7 @@ components:
         properties:
             protocol: 
               $ref: "#/components/schemas/Protocol"
-            sources:
+            data:
                 type: array
                 items:
                   $ref: "#/components/schemas/Source"
@@ -1097,7 +1094,7 @@ components:
             - size: 30
             - totalHits: 1234
             - page: 2
-          - sources:
+          - data:
             - "@id": source 1
             - ...
             - "@id": source 2
@@ -1156,10 +1153,11 @@ components:
 ##            type: string
         formats:
           type: array
-          description: >
-            List of the supported response formats (content types). E.g. 
+          description: "List of the supported response formats (content types). E.g. 
             ``application/json`` (default), ``application/xml``, ``application/rdf+xml``,
-            ``application/x-turtle``, ...
+            ``application/x-turtle``, ..."
+          items:
+            type: string
             
       example:
         - description: Prosopographical data from the 1890 census

--- a/prosoprAPhI.yaml
+++ b/prosoprAPhI.yaml
@@ -334,10 +334,7 @@ paths:
           content:
             application/json:
               schema:
-                title: Array of Statement objects
-                type: array
-                items:
-                  $ref: "#/components/schemas/Statement"
+                  $ref: "#/components/schemas/StatementsResponse"
         "400":
           $ref: "#/components/responses/BadRequestError"
         "500":
@@ -668,7 +665,8 @@ components:
             format: uri
         example:
           - "@id": TW_Pez1_809_1
-            person: Andreas_Reuter
+            person: 
+              "@id": Andreas_Reuter
             statements:
               - "@id": Pez1_809_1
                 statementContents:
@@ -685,7 +683,8 @@ components:
             modifiedBy: Thomas Wallnig
             modifiedWhen: 2010-05-05
           - "@id": TW_Pez1_123456
-            person: Placidus_Seiz
+            person: 
+              "@id": Placidus_Seiz
             statements:
               - "@id": Pez#474-7,
                 statementContents:
@@ -697,19 +696,20 @@ components:
             modifiedBy: Thomas Wallnig
             modifiedWhen: 2007-04-16
           - "@id": TW_Pez1_123456
-            person: Placidus_Seiz
+            person: 
+              "@id": Placidus_Seiz
+              uris: http://pez-digital.at/placidus_Seiz
             statements:
               "@id": person1241
               name: Placidus Seitz
-              uris: 
-                - http://pez-digital.at/placidus_Seiz
             source: Lindner-Album_Ettalense253f.
             createdBy: Thomas Wallnig
             createdWhen: 2007-04-16
             modifiedBy: Thomas Wallnig
             modifiedWhen: 2007-07-01
           - "@id": Fd2qwr
-            person: Andreas_Reuter
+            person: 
+              "@id" : Andreas_Reuter
             statements:
               - "@id": Fd2qwr
                 date:
@@ -797,7 +797,8 @@ components:
             - page: 2
           - data: 
             - "@id": TW_Pez1_809_1
-              person: Andreas_Reuter
+              person: 
+                "@id" : Andreas_Reuter
               statements:
                 - "@id": Pez1_809_1
                   statementContents:
@@ -814,7 +815,8 @@ components:
               modifiedBy: Thomas Wallnig
               modifiedWhen: 2010-05-05
             - "@id": TW_Pez1_123456
-              person: Placidus_Seiz
+              person: 
+                "@id" : Placidus_Seiz
               statements:
                 - "@id": Pez#474-7,
                   statementContents:
@@ -826,7 +828,8 @@ components:
               modifiedBy: Thomas Wallnig
               modifiedWhen: 2007-04-16
             - "@id": TW_Pez1_123456
-              person: Placidus_Seiz
+              person:
+                "@id" : Placidus_Seiz
               statements:
                 "@id": person1241
                 name: Placidus Seitz
@@ -898,13 +901,8 @@ components:
       properties:
         "@id":
           $ref: "#/components/schemas/id"
-        uri:
-          type: string
-          format: uri
-          description: A fully dereferencably URI representing the statement in the
-            internet, usually different from the URI created by the use of this
-            API. The API recommends to serve requests for serialisations of W3C
-            RDF via this URI.
+        uris:
+          $ref: "#/components/schemas/uris"
         statementType:
           type: object
           description: in context of structured information (with places, relationships,
@@ -1170,7 +1168,7 @@ components:
       description: the local id of the object (factoid, person, source, statement)
       type: string
     uri:
-      description: the uri of an object (factoid, person, source, statement, etc.).
+      description: the uri of an object (role, place, organisation, type, factoid, person, source, statement, etc.).
       type: string
       format: uri
     uris:


### PR DESCRIPTION
Responses to the listing endpoints (/factoids, /statements etc.) looked like this:
```
{
   'protocol': {..},
   'factoids': []
}
{
   'protocol': {..},
   'statements': []
}
```

When writing tests I got repeatedly confused with the different names. So I unified them for all listing endpoints to 

```
{
   'protocol': {..},
   'data': []
}
```

Also made some minor changes:
   - re-introduced sortBy for factoids because someone might want to sort by @id createdBy etc.
   - fixed the response schema for /persons, /statements and /sources. These schemas were already defined, but not used in the paths defintions.