### PR TITLE
Add missing (implicit) types to schemas

### DIFF
--- a/prosopogrAPhI.yaml
+++ b/prosopogrAPhI.yaml
@@ -889,6 +889,7 @@ components:
             - '@id': st2
             - ...
     Protocol:
+      type: object
       description: Provides metadata about the current request
       properties:
         size:
@@ -901,6 +902,7 @@ components:
           type: integer
           description: Total number of objects found by this request
     Source:
+      type: object  
       required:
         - '@id'
       properties:
@@ -1027,6 +1029,7 @@ components:
       type: string
       format: date
     Error:
+      type: object
       required:
         - status
         - title


### PR DESCRIPTION
Some schemas did not explicitly set the type 'object', which is fixed now.